### PR TITLE
Strip Quotes from path variable to avoid creating broken path's

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "voicemeeter-api"
-version = "2.5.3"
+version = "2.5.4"
 description = "A Python wrapper for the Voiceemeter API"
 authors = ["onyx-and-iris <code@onyxandiris.online>"]
 license = "MIT"

--- a/voicemeeterlib/inst.py
+++ b/voicemeeterlib/inst.py
@@ -31,7 +31,7 @@ def get_vmpath():
     with winreg.OpenKey(
         winreg.HKEY_LOCAL_MACHINE, r"{}".format("\\".join((REG_KEY, VM_KEY)))
     ) as vm_key:
-        return winreg.QueryValueEx(vm_key, r"UninstallString")[0]
+        return winreg.QueryValueEx(vm_key, r"UninstallString")[0].strip("\"")
 
 
 try:

--- a/voicemeeterlib/inst.py
+++ b/voicemeeterlib/inst.py
@@ -31,7 +31,7 @@ def get_vmpath():
     with winreg.OpenKey(
         winreg.HKEY_LOCAL_MACHINE, r"{}".format("\\".join((REG_KEY, VM_KEY)))
     ) as vm_key:
-        return winreg.QueryValueEx(vm_key, r"UninstallString")[0].strip("\"")
+        return winreg.QueryValueEx(vm_key, r"UninstallString")[0].strip('"')
 
 
 try:


### PR DESCRIPTION
Update inst.py
Strip Quotes from path variable to avoid creating broken path's when calling .parent
Fixes this issue: https://github.com/onyx-and-iris/voicemeeter-api-python/issues/12 